### PR TITLE
Update rails upper version limit to "< 6.0"

### DIFF
--- a/glipper.gemspec
+++ b/glipper.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "actionpack", ">= 4.1.1", "< 5.2"
+  spec.add_dependency "actionpack", ">= 4.1.1", "< 6.0"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Only `ActionController::Base.helpers` used for initialization purposes. Probably, this API will not be changed.